### PR TITLE
adjusted time strings in noaa_coops

### DIFF
--- a/cht_observations/_noaa_coops.py
+++ b/cht_observations/_noaa_coops.py
@@ -66,8 +66,8 @@ class Source(StationSource):
         df : pandas.DataFrame
             Data frame with data
         """
-        t0_string = tstart.strftime("%Y%m%d")
-        t1_string = tstop.strftime("%Y%m%d")
+        t0_string = tstart.strftime("%Y%m%d %H:%M")
+        t1_string = tstop.strftime("%Y%m%d %H:%M")
 
         if varname == "water_level":
             product = varname


### PR DESCRIPTION
Hi Maarten, 

Kathryn noticed that the tide gauge download would always go from midnight to midnight, regardless the start and end time set in the FloodAdapt. I adjusted the start and end time string creation in _noaa_coops.py to also include hours and minutes. Will this break anything else where you use this?

See https://github.com/Deltares-research/FloodAdapt/issues/369